### PR TITLE
invalid env format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV PATH=$PATH:/usr/local/nginx/sbin
+ENV PATH $PATH:/usr/local/nginx/sbin
 
 EXPOSE 1935
 EXPOSE 80


### PR DESCRIPTION
i'm not sure if i'm on an old docker version or not, but i had to fix this line to get it to build. feel free to disregard if it's just my docker being old
