### PR TITLE
fix apt-repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:trusty
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH $PATH:/usr/local/nginx/sbin


### PR DESCRIPTION
Fix add-apt-repository ppa:mc3man/trusty-media when doesn't work on latest ubuntu
