### PR TITLE
Update nginx to 1.7.5 and always send CORS header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,16 +26,16 @@ RUN apt-get update && \
 
 # get nginx source
 WORKDIR /src
-RUN wget http://nginx.org/download/nginx-1.6.2.tar.gz && \
-  tar zxf nginx-1.6.2.tar.gz && \
-  rm nginx-1.6.2.tar.gz && \
+RUN wget http://nginx.org/download/nginx-1.7.5tar.gz && \
+  tar zxf nginx-1.7.5.tar.gz && \
+  rm nginx-1.7.5.tar.gz && \
 # get nginx-rtmp module
   wget https://github.com/arut/nginx-rtmp-module/archive/v1.1.6.tar.gz && \
   tar zxf v1.1.6.tar.gz && \
   rm v1.1.6.tar.gz
 
 # compile nginx
-WORKDIR /src/nginx-1.6.2
+WORKDIR /src/nginx-1.7.5
 RUN ./configure --add-module=/src/nginx-rtmp-module-1.1.6 \
   --conf-path=/config/nginx.conf \
   --error-log-path=/logs/error.log \

--- a/nginx.conf
+++ b/nginx.conf
@@ -48,7 +48,7 @@ http {
             }
             root /data;
             add_header Cache-Control no-cache;
-            add_header Access-Control-Allow-Origin *;
+            add_header Access-Control-Allow-Origin * always;
         }
 
         location /stat {


### PR DESCRIPTION
I did this change a few months back but forgot to push back upstream. The configuration worked out of the box for me other than this, and I didn't run into any issues during the event, 3-4 hours continuous streaming at a one-off event - so I make no promises about unintended side-effects for other use cases.

*add_header [...] always* requires >= 1.7.5 as per https://nginx.org/en/docs/http/ngx_http_headers_module.html

Given that, I only updated to the minimum version that supported the option to avoid the need for more significant testing. I've included the relevant changelog entries for nginx below for convenience, but they can also be seen at https://nginx.org/en/CHANGES and https://nginx.org/en/CHANGES-1.6

<details>
  <summary>Changes between nginx 1.6.2 and 1.7.5</summary>
Changes with nginx 1.7.5                                         16 Sep 2014

    *) Security: it was possible to reuse SSL sessions in unrelated contexts
       if a shared SSL session cache or the same TLS session ticket key was
       used for multiple "server" blocks (CVE-2014-3616).
       Thanks to Antoine Delignat-Lavaud.

    *) Change: now the "stub_status" directive does not require a parameter.

    *) Feature: the "always" parameter of the "add_header" directive.

    *) Feature: the "proxy_next_upstream_tries",
       "proxy_next_upstream_timeout", "fastcgi_next_upstream_tries",
       "fastcgi_next_upstream_timeout", "memcached_next_upstream_tries",
       "memcached_next_upstream_timeout", "scgi_next_upstream_tries",
       "scgi_next_upstream_timeout", "uwsgi_next_upstream_tries", and
       "uwsgi_next_upstream_timeout" directives.

    *) Bugfix: in the "if" parameter of the "access_log" directive.

    *) Bugfix: in the ngx_http_perl_module.
       Thanks to Piotr Sikora.

    *) Bugfix: the "listen" directive of the mail proxy module did not allow
       to specify more than two parameters.

    *) Bugfix: the "sub_filter" directive did not work with a string to
       replace consisting of a single character.

    *) Bugfix: requests might hang if resolver was used and a timeout
       occurred during a DNS request.

    *) Bugfix: in the ngx_http_spdy_module when using with AIO.

    *) Bugfix: a segmentation fault might occur in a worker process if the
       "set" directive was used to change the "$http_...", "$sent_http_...",
       or "$upstream_http_..." variables.

    *) Bugfix: in memory allocation error handling.
       Thanks to Markus Linnala and Feng Gu.


Changes with nginx 1.7.4                                         05 Aug 2014

    *) Security: pipelined commands were not discarded after STARTTLS
       command in SMTP proxy (CVE-2014-3556); the bug had appeared in 1.5.6.
       Thanks to Chris Boulton.

    *) Change: URI escaping now uses uppercase hexadecimal digits.
       Thanks to Piotr Sikora.

    *) Feature: now nginx can be build with BoringSSL and LibreSSL.
       Thanks to Piotr Sikora.

    *) Bugfix: requests might hang if resolver was used and a DNS server
       returned a malformed response; the bug had appeared in 1.5.8.

    *) Bugfix: in the ngx_http_spdy_module.
       Thanks to Piotr Sikora.

    *) Bugfix: the $uri variable might contain garbage when returning errors
       with code 400.
       Thanks to Sergey Bobrov.

    *) Bugfix: in error handling in the "proxy_store" directive and the
       ngx_http_dav_module.
       Thanks to Feng Gu.

    *) Bugfix: a segmentation fault might occur if logging of errors to
       syslog was used; the bug had appeared in 1.7.1.

    *) Bugfix: the $geoip_latitude, $geoip_longitude, $geoip_dma_code, and
       $geoip_area_code variables might not work.
       Thanks to Yichun Zhang.

    *) Bugfix: in memory allocation error handling.
       Thanks to Tatsuhiko Kubo and Piotr Sikora.


Changes with nginx 1.7.3                                         08 Jul 2014

    *) Feature: weak entity tags are now preserved on response
       modifications, and strong ones are changed to weak.

    *) Feature: cache revalidation now uses If-None-Match header if
       possible.

    *) Feature: the "ssl_password_file" directive.

    *) Bugfix: the If-None-Match request header line was ignored if there
       was no Last-Modified header in a response returned from cache.

    *) Bugfix: "peer closed connection in SSL handshake" messages were
       logged at "info" level instead of "error" while connecting to
       backends.

    *) Bugfix: in the ngx_http_dav_module module in nginx/Windows.

    *) Bugfix: SPDY connections might be closed prematurely if caching was
       used.


Changes with nginx 1.7.2                                         17 Jun 2014

    *) Feature: the "hash" directive inside the "upstream" block.

    *) Feature: defragmentation of free shared memory blocks.
       Thanks to Wandenberg Peixoto and Yichun Zhang.

    *) Bugfix: a segmentation fault might occur in a worker process if the
       default value of the "access_log" directive was used; the bug had
       appeared in 1.7.0.
       Thanks to Piotr Sikora.

    *) Bugfix: trailing slash was mistakenly removed from the last parameter
       of the "try_files" directive.

    *) Bugfix: nginx could not be built on OS X in some cases.

    *) Bugfix: in the ngx_http_spdy_module.


Changes with nginx 1.7.1                                         27 May 2014

    *) Feature: the "$upstream_cookie_..." variables.

    *) Feature: the $ssl_client_fingerprint variable.

    *) Feature: the "error_log" and "access_log" directives now support
       logging to syslog.

    *) Feature: the mail proxy now logs client port on connect.

    *) Bugfix: memory leak if the "ssl_stapling" directive was used.
       Thanks to Filipe da Silva.

    *) Bugfix: the "alias" directive used inside a location given by a
       regular expression worked incorrectly if the "if" or "limit_except"
       directives were used.

    *) Bugfix: the "charset" directive did not set a charset to encoded
       backend responses.

    *) Bugfix: a "proxy_pass" directive without URI part might use original
       request after the $args variable was set.
       Thanks to Yichun Zhang.

    *) Bugfix: in the "none" parameter in the "smtp_auth" directive; the bug
       had appeared in 1.5.6.
       Thanks to Svyatoslav Nikolsky.

    *) Bugfix: if sub_filter and SSI were used together, then responses
       might be transferred incorrectly.

    *) Bugfix: nginx could not be built with the --with-file-aio option on
       Linux/aarch64.


Changes with nginx 1.7.0                                         24 Apr 2014

    *) Feature: backend SSL certificate verification.

    *) Feature: support for SNI while working with SSL backends.

    *) Feature: the $ssl_server_name variable.

    *) Feature: the "if" parameter of the "access_log" directive.

Changes with nginx 1.6.3                                         07 Apr 2015

    *) Feature: now the "tcp_nodelay" directive works with SPDY connections.

    *) Bugfix: in error handling.
       Thanks to Yichun Zhang and Daniil Bondarev.

    *) Bugfix: alerts "header already sent" appeared in logs if the
       "post_action" directive was used; the bug had appeared in 1.5.4.

    *) Bugfix: alerts "sem_post() failed" might appear in logs.

    *) Bugfix: in hash table handling.
       Thanks to Chris West.

    *) Bugfix: in integer overflow handling.
       Thanks to Régis Leroy.
</details>